### PR TITLE
Fix pixel grid coverage

### DIFF
--- a/modes/pixel.js
+++ b/modes/pixel.js
@@ -20,8 +20,9 @@ export function generatePixelMap() {
   }
 
   ctx.clearRect(0, 0, canvas.width, canvas.height);
-  const cols = Math.floor(canvas.width / pixelSize);
-  const rows = Math.floor(canvas.height / pixelSize);
+  // Ensure the pixel grid fully covers the canvas
+  const cols = Math.ceil(canvas.width / pixelSize);
+  const rows = Math.ceil(canvas.height / pixelSize);
 
   const temp = document.createElement('canvas');
   temp.width = cols;


### PR DESCRIPTION
## Summary
- ensure the generated pixel map covers the entire canvas by rounding up the grid size

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6859c06f1224832cb036cb7b6da7b42a