### PR TITLE
Add mode selection system

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,12 +2,14 @@
 <html lang="fr">
 <head>
   <meta charset="UTF-8" />
-  <title>Stéganographie Pixel Map</title>
+  <title>Stéganographie Generator</title>
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <h1>Stéganographie Pixel Map</h1>
+  <h1>Stéganographie Generator</h1>
   <div class="control-group">
+    <label for="mode">Mode :</label>
+    <select id="mode"></select>
     <label for="backgroundColors">Couleurs de fond :</label>
     <input type="text" id="backgroundColors" value="#FF5733, #33FF57, #3357FF, #F3FF33, #33FFF3" />
     <div class="color-preview" id="bgColorPreview"></div>

--- a/main.js
+++ b/main.js
@@ -1,7 +1,39 @@
-import { generatePixelMap } from './modes/pixel.js';
-import { setupPreview, setupMaskUpload } from './utils.js';
+import modes from './modes/index.js';
+import { setupPreview, updateColorPreview, setupMaskUpload } from './utils.js';
 
-window.generate = () => generatePixelMap();
+function applyModeOptions(opts) {
+  if (!opts) return;
+  Object.entries(opts).forEach(([id, value]) => {
+    const el = document.getElementById(id);
+    if (el) {
+      el.value = value;
+    }
+  });
+  updateColorPreview('backgroundColors', 'bgColorPreview');
+  updateColorPreview('textColors', 'textColorPreview');
+}
+
+function setupModes() {
+  const select = document.getElementById('mode');
+  modes.forEach(mode => {
+    const option = document.createElement('option');
+    option.value = mode.name;
+    option.textContent = mode.name;
+    select.appendChild(option);
+  });
+
+  const setMode = () => {
+    const mode = modes.find(m => m.name === select.value);
+    applyModeOptions(mode.options);
+    window.generate = () => mode.generate();
+  };
+
+  select.addEventListener('change', setMode);
+
+  select.value = modes[0].name;
+  setMode();
+}
 
 setupPreview();
 setupMaskUpload();
+setupModes();

--- a/modes/index.js
+++ b/modes/index.js
@@ -1,0 +1,3 @@
+import pixel from './pixel.js';
+
+export default [pixel];

--- a/modes/pixel.js
+++ b/modes/pixel.js
@@ -67,3 +67,19 @@ export function generatePixelMap() {
     ctx.globalCompositeOperation = 'source-over';
   }
 }
+
+export default {
+  name: 'Pixel',
+  generate: generatePixelMap,
+  options: {
+    backgroundColors: '#FF5733, #33FF57, #3357FF, #F3FF33, #33FFF3',
+    textColors: '#000000, #222222, #111111',
+    pixelSize: 5,
+    hiddenText: 'Hello',
+    textSize: 25,
+    textX: 50,
+    textY: 50,
+    textAngle: 0,
+    textNoise: 10
+  }
+};

--- a/utils.js
+++ b/utils.js
@@ -5,26 +5,26 @@ export function parseColors(str) {
     .map(c => c.startsWith('#') ? c : '#' + c);
 }
 
+export function updateColorPreview(inputId, previewId) {
+  const colors = parseColors(document.getElementById(inputId).value);
+  const preview = document.getElementById(previewId);
+  preview.innerHTML = '';
+  colors.forEach(color => {
+    const box = document.createElement('div');
+    box.className = 'color-box';
+    box.style.backgroundColor = color;
+    preview.appendChild(box);
+  });
+}
+
 export function setupPreview() {
-  const update = (inputId, previewId) => {
-    const colors = parseColors(document.getElementById(inputId).value);
-    const preview = document.getElementById(previewId);
-    preview.innerHTML = '';
-    colors.forEach(color => {
-      const box = document.createElement('div');
-      box.className = 'color-box';
-      box.style.backgroundColor = color;
-      preview.appendChild(box);
-    });
-  };
-
   document.getElementById('backgroundColors').addEventListener('input', () =>
-    update('backgroundColors', 'bgColorPreview'));
+    updateColorPreview('backgroundColors', 'bgColorPreview'));
   document.getElementById('textColors').addEventListener('input', () =>
-    update('textColors', 'textColorPreview'));
+    updateColorPreview('textColors', 'textColorPreview'));
 
-  update('backgroundColors', 'bgColorPreview');
-  update('textColors', 'textColorPreview');
+  updateColorPreview('backgroundColors', 'bgColorPreview');
+  updateColorPreview('textColors', 'textColorPreview');
 }
 
 export let maskImage = null;


### PR DESCRIPTION
## Summary
- add a dropdown to choose generation mode
- create module registry for modes
- expose a preview refresh helper in `utils.js`
- register Pixel mode with defaults
- switch options when selecting a mode

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6859c126732c832c9f2a9a243eedf6e7