### PR TITLE
Add blur control for Pixel Smooth mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -39,6 +39,9 @@
     <label for="textNoise">Bruit texte (%):</label>
     <input type="number" id="textNoise" value="10" min="0" max="100" />
 
+    <label for="blurRadius">Flou (px) :</label>
+    <input type="number" id="blurRadius" value="2" min="0" max="20" />
+
     <label for="maskUpload">Téléverser un masque SVG :</label>
     <input type="file" id="maskUpload" accept=".svg" />
 

--- a/modes/pixel.js
+++ b/modes/pixel.js
@@ -80,6 +80,7 @@ export default {
     textX: 50,
     textY: 50,
     textAngle: 0,
-    textNoise: 10
+    textNoise: 10,
+    blurRadius: 0
   }
 };

--- a/modes/pixelSmooth.js
+++ b/modes/pixelSmooth.js
@@ -4,19 +4,25 @@ export function generateSmoothPixelMap() {
   generatePixelMap();
   const canvas = document.getElementById('canvas');
   const ctx = canvas.getContext('2d');
-  const tmp = document.createElement('canvas');
-  tmp.width = canvas.width;
-  tmp.height = canvas.height;
-  const tctx = tmp.getContext('2d');
-  tctx.drawImage(canvas, 0, 0);
-  ctx.clearRect(0, 0, canvas.width, canvas.height);
-  ctx.filter = 'blur(2px)';
-  ctx.drawImage(tmp, 0, 0);
-  ctx.filter = 'none';
+  const blurRadius = parseFloat(document.getElementById('blurRadius').value) || 0;
+  if (blurRadius > 0) {
+    const tmp = document.createElement('canvas');
+    tmp.width = canvas.width;
+    tmp.height = canvas.height;
+    const tctx = tmp.getContext('2d');
+    tctx.drawImage(canvas, 0, 0);
+    ctx.clearRect(0, 0, canvas.width, canvas.height);
+    ctx.filter = `blur(${blurRadius}px)`;
+    ctx.drawImage(tmp, 0, 0);
+    ctx.filter = 'none';
+  }
 }
 
 export default {
   name: 'Pixel Smooth',
   generate: generateSmoothPixelMap,
-  options: pixel.options
+  options: {
+    ...pixel.options,
+    blurRadius: 2
+  }
 };


### PR DESCRIPTION
## Summary
- allow choosing blur strength for Pixel Smooth mode
- include `blurRadius` in default options
- expose new blur input in the UI

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6859c3ce44e0832cad1b77fbc221098e