### PR TITLE
Improve pixel blending and option visibility

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,9 @@
     <label for="blurRadius">Flou (px) :</label>
     <input type="number" id="blurRadius" value="2" min="0" max="20" />
 
+    <label for="blendStrength">Puissance mélange (%):</label>
+    <input type="number" id="blendStrength" value="50" min="0" max="100" />
+
     <label for="maskUpload">Téléverser un masque SVG :</label>
     <input type="file" id="maskUpload" accept=".svg" />
 

--- a/main.js
+++ b/main.js
@@ -1,7 +1,51 @@
 import modes from './modes/index.js';
 import { setupPreview, updateColorPreview, setupMaskUpload } from './utils.js';
 
-function applyModeOptions(opts) {
+const allOptionIds = [
+  'backgroundColors',
+  'textColors',
+  'pixelSize',
+  'hiddenText',
+  'textSize',
+  'textX',
+  'textY',
+  'textAngle',
+  'textNoise',
+  'blurRadius',
+  'blendStrength'
+];
+
+function toggleOptions(visible = []) {
+  allOptionIds.forEach(id => {
+    const input = document.getElementById(id);
+    const label = document.querySelector(`label[for="${id}"]`);
+    const preview =
+      id === 'backgroundColors'
+        ? document.getElementById('bgColorPreview')
+        : id === 'textColors'
+          ? document.getElementById('textColorPreview')
+          : null;
+    if (input) input.classList.add('hidden');
+    if (label) label.classList.add('hidden');
+    if (preview) preview.classList.add('hidden');
+  });
+  visible.forEach(id => {
+    const input = document.getElementById(id);
+    const label = document.querySelector(`label[for="${id}"]`);
+    const preview =
+      id === 'backgroundColors'
+        ? document.getElementById('bgColorPreview')
+        : id === 'textColors'
+          ? document.getElementById('textColorPreview')
+          : null;
+    if (input) input.classList.remove('hidden');
+    if (label) label.classList.remove('hidden');
+    if (preview) preview.classList.remove('hidden');
+  });
+}
+
+function applyModeOptions(opts, visible) {
+  toggleOptions(visible);
   if (!opts) return;
   Object.entries(opts).forEach(([id, value]) => {
     const el = document.getElementById(id);
@@ -24,7 +68,7 @@ function setupModes() {
 
   const setMode = () => {
     const mode = modes.find(m => m.name === select.value);
-    applyModeOptions(mode.options);
+    applyModeOptions(mode.options, mode.visibleOptions || allOptionIds);
     window.generate = () => mode.generate();
   };
 

--- a/modes/index.js
+++ b/modes/index.js
@@ -1,4 +1,5 @@
 import pixel from './pixel.js';
 import pixelSmooth from './pixelSmooth.js';
+import pixelBlend from './pixelBlend.js';
 
-export default [pixel, pixelSmooth];
+export default [pixel, pixelSmooth, pixelBlend];

--- a/modes/pixel.js
+++ b/modes/pixel.js
@@ -80,7 +80,10 @@ export default {
     textX: 50,
     textY: 50,
     textAngle: 0,
-    textNoise: 10,
-    blurRadius: 0
-  }
+    textNoise: 10
+  },
+  visibleOptions: [
+    'backgroundColors', 'textColors', 'pixelSize', 'hiddenText', 'textSize',
+    'textX', 'textY', 'textAngle', 'textNoise'
+  ]
 };

--- a/modes/pixelBlend.js
+++ b/modes/pixelBlend.js
@@ -1,0 +1,57 @@
+import pixel, { generatePixelMap } from './pixel.js';
+
+export function generateBlendPixelMap() {
+  generatePixelMap();
+  const canvas = document.getElementById('canvas');
+  const ctx = canvas.getContext('2d');
+  const strength =
+    (parseFloat(document.getElementById('blendStrength').value) || 50) / 100;
+
+  const width = canvas.width;
+  const height = canvas.height;
+  const src = ctx.getImageData(0, 0, width, height);
+  const data = src.data;
+  const out = new Uint8ClampedArray(data.length);
+
+  for (let y = 0; y < height; y++) {
+    for (let x = 0; x < width; x++) {
+      let r = 0,
+        g = 0,
+        b = 0,
+        count = 0;
+      for (let dy = -1; dy <= 1; dy++) {
+        for (let dx = -1; dx <= 1; dx++) {
+          const nx = x + dx;
+          const ny = y + dy;
+          if (nx >= 0 && nx < width && ny >= 0 && ny < height) {
+            const idx = (ny * width + nx) * 4;
+            r += data[idx];
+            g += data[idx + 1];
+            b += data[idx + 2];
+            count++;
+          }
+        }
+      }
+      const idx = (y * width + x) * 4;
+      const ar = r / count;
+      const ag = g / count;
+      const ab = b / count;
+      out[idx] = data[idx] * (1 - strength) + ar * strength;
+      out[idx + 1] = data[idx + 1] * (1 - strength) + ag * strength;
+      out[idx + 2] = data[idx + 2] * (1 - strength) + ab * strength;
+      out[idx + 3] = 255;
+    }
+  }
+
+  ctx.putImageData(new ImageData(out, width, height), 0, 0);
+}
+
+export default {
+  name: 'Pixel Blend',
+  generate: generateBlendPixelMap,
+  options: {
+    ...pixel.options,
+    blendStrength: 50
+  },
+  visibleOptions: [...pixel.visibleOptions, 'blendStrength']
+};

--- a/modes/pixelSmooth.js
+++ b/modes/pixelSmooth.js
@@ -24,5 +24,6 @@ export default {
   options: {
     ...pixel.options,
     blurRadius: 2
-  }
+  },
+  visibleOptions: [...pixel.visibleOptions, 'blurRadius']
 };

--- a/style.css
+++ b/style.css
@@ -62,3 +62,7 @@ canvas {
   border: 1px solid #333;
   border-radius: 3px;
 }
+
+.hidden {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- support per-mode option visibility
- implement adjustable blending strength with new input
- hide/show controls depending on chosen mode
- add `.hidden` style helper for UI

## Testing
- `node --version`
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_6859c52867b4832cafe125646e5c047a