### PR TITLE
Add experimental color steganography modes

### DIFF
--- a/index.html
+++ b/index.html
@@ -42,6 +42,16 @@
     <label for="blurRadius">Flou (px) :</label>
     <input type="number" id="blurRadius" value="2" min="0" max="20" />
 
+    <label for="channel">Canal couleur :</label>
+    <select id="channel">
+      <option value="R">Rouge</option>
+      <option value="G">Vert</option>
+      <option value="B">Bleu</option>
+    </select>
+
+    <label for="contrast">Contraste (%):</label>
+    <input type="number" id="contrast" value="10" min="0" max="100" />
+
     <label for="maskUpload">Téléverser un masque SVG :</label>
     <input type="file" id="maskUpload" accept=".svg" />
     <button onclick="generate()">Générer</button>

--- a/main.js
+++ b/main.js
@@ -11,7 +11,9 @@ const allOptionIds = [
   'textY',
   'textAngle',
   'textNoise',
-  'blurRadius'
+  'blurRadius',
+  'channel',
+  'contrast'
 ];
 
 function toggleOptions(visible = []) {

--- a/modes/anaglyph.js
+++ b/modes/anaglyph.js
@@ -1,0 +1,81 @@
+import pixel from './pixel.js';
+import { parseColors, maskImage, hexToRgb, rgbToHex } from '../utils.js';
+
+export function generateAnaglyph() {
+  const canvas = document.getElementById('canvas');
+  const ctx = canvas.getContext('2d');
+
+  const bgColors = parseColors(document.getElementById('backgroundColors').value);
+  const textColors = parseColors(document.getElementById('textColors').value);
+  const text = document.getElementById('hiddenText').value.trim();
+  const pixelSize = parseInt(document.getElementById('pixelSize').value);
+  const textSizePercent = parseFloat(document.getElementById('textSize').value);
+  const posXPercent = parseFloat(document.getElementById('textX').value);
+  const posYPercent = parseFloat(document.getElementById('textY').value);
+  const angleDeg = parseFloat(document.getElementById('textAngle').value);
+  const textNoise = parseFloat(document.getElementById('textNoise').value) || 0;
+
+  if (!text || bgColors.length === 0 || textColors.length === 0) {
+    alert('Veuillez fournir un texte, des couleurs de fond et de texte.');
+    return;
+  }
+
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const cols = Math.floor(canvas.width / pixelSize);
+  const rows = Math.floor(canvas.height / pixelSize);
+
+  const temp = document.createElement('canvas');
+  temp.width = cols;
+  temp.height = rows;
+  const tctx = temp.getContext('2d');
+
+  tctx.fillStyle = 'white';
+  tctx.fillRect(0, 0, cols, rows);
+
+  tctx.save();
+  const centerX = (posXPercent / 100) * cols;
+  const centerY = (posYPercent / 100) * rows;
+  const angleRad = angleDeg * Math.PI / 180;
+  tctx.translate(centerX, centerY);
+  tctx.rotate(angleRad);
+  const fontSize = Math.floor((textSizePercent / 100) * rows);
+  tctx.font = `bold ${fontSize}px monospace`;
+  tctx.textAlign = 'center';
+  tctx.textBaseline = 'middle';
+  tctx.fillStyle = 'black';
+  tctx.fillText(text, 0, 0);
+  tctx.restore();
+
+  const mask = tctx.getImageData(0, 0, cols, rows).data;
+
+  for (let y = 0; y < rows; y++) {
+    for (let x = 0; x < cols; x++) {
+      const index = (y * cols + x) * 4;
+      const isText = mask[index] < 128;
+      const base = hexToRgb(bgColors[Math.floor(Math.random() * bgColors.length)]);
+      let color = { ...base };
+      if (isText || Math.random() * 100 < textNoise) {
+        const txt = hexToRgb(textColors[Math.floor(Math.random() * textColors.length)]);
+        // encode in red and cyan
+        color.r = txt.r;
+        color.g = txt.g;
+        color.b = base.b;
+      }
+      ctx.fillStyle = rgbToHex(color);
+      ctx.fillRect(x * pixelSize, y * pixelSize, pixelSize, pixelSize);
+    }
+  }
+
+  if (maskImage) {
+    ctx.globalCompositeOperation = 'destination-in';
+    ctx.drawImage(maskImage, 0, 0, canvas.width, canvas.height);
+    ctx.globalCompositeOperation = 'source-over';
+  }
+}
+
+export default {
+  name: 'Anaglyphe',
+  generate: generateAnaglyph,
+  options: pixel.options,
+  visibleOptions: pixel.visibleOptions
+};

--- a/modes/chromaticInvert.js
+++ b/modes/chromaticInvert.js
@@ -1,0 +1,86 @@
+import pixel from './pixel.js';
+import { parseColors, maskImage, hexToRgb, rgbToHex } from '../utils.js';
+
+function invertColor(c) {
+  return {
+    r: 255 - c.r,
+    g: 255 - c.g,
+    b: 255 - c.b
+  };
+}
+
+export function generateChromaticInvert() {
+  const canvas = document.getElementById('canvas');
+  const ctx = canvas.getContext('2d');
+
+  const bgColors = parseColors(document.getElementById('backgroundColors').value);
+  const textColors = parseColors(document.getElementById('textColors').value);
+  const text = document.getElementById('hiddenText').value.trim();
+  const pixelSize = parseInt(document.getElementById('pixelSize').value);
+  const textSizePercent = parseFloat(document.getElementById('textSize').value);
+  const posXPercent = parseFloat(document.getElementById('textX').value);
+  const posYPercent = parseFloat(document.getElementById('textY').value);
+  const angleDeg = parseFloat(document.getElementById('textAngle').value);
+  const textNoise = parseFloat(document.getElementById('textNoise').value) || 0;
+
+  if (!text || bgColors.length === 0 || textColors.length === 0) {
+    alert('Veuillez fournir un texte, des couleurs de fond et de texte.');
+    return;
+  }
+
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const cols = Math.floor(canvas.width / pixelSize);
+  const rows = Math.floor(canvas.height / pixelSize);
+
+  const temp = document.createElement('canvas');
+  temp.width = cols;
+  temp.height = rows;
+  const tctx = temp.getContext('2d');
+
+  tctx.fillStyle = 'white';
+  tctx.fillRect(0, 0, cols, rows);
+
+  tctx.save();
+  const centerX = (posXPercent / 100) * cols;
+  const centerY = (posYPercent / 100) * rows;
+  const angleRad = angleDeg * Math.PI / 180;
+  tctx.translate(centerX, centerY);
+  tctx.rotate(angleRad);
+  const fontSize = Math.floor((textSizePercent / 100) * rows);
+  tctx.font = `bold ${fontSize}px monospace`;
+  tctx.textAlign = 'center';
+  tctx.textBaseline = 'middle';
+  tctx.fillStyle = 'black';
+  tctx.fillText(text, 0, 0);
+  tctx.restore();
+
+  const mask = tctx.getImageData(0, 0, cols, rows).data;
+
+  for (let y = 0; y < rows; y++) {
+    for (let x = 0; x < cols; x++) {
+      const index = (y * cols + x) * 4;
+      const isText = mask[index] < 128;
+      const base = hexToRgb(bgColors[Math.floor(Math.random() * bgColors.length)]);
+      let color = { ...base };
+      if (isText || Math.random() * 100 < textNoise) {
+        const txt = hexToRgb(textColors[Math.floor(Math.random() * textColors.length)]);
+        color = invertColor(txt);
+      }
+      ctx.fillStyle = rgbToHex(color);
+      ctx.fillRect(x * pixelSize, y * pixelSize, pixelSize, pixelSize);
+    }
+  }
+
+  if (maskImage) {
+    ctx.globalCompositeOperation = 'destination-in';
+    ctx.drawImage(maskImage, 0, 0, canvas.width, canvas.height);
+    ctx.globalCompositeOperation = 'source-over';
+  }
+}
+
+export default {
+  name: 'Inversion Chromatique',
+  generate: generateChromaticInvert,
+  options: pixel.options,
+  visibleOptions: pixel.visibleOptions
+};

--- a/modes/dichromatic.js
+++ b/modes/dichromatic.js
@@ -1,0 +1,91 @@
+import pixel from './pixel.js';
+import { parseColors, maskImage, hexToRgb, rgbToHex } from '../utils.js';
+
+export function generateDichromatic() {
+  const canvas = document.getElementById('canvas');
+  const ctx = canvas.getContext('2d');
+
+  const bgColors = parseColors(document.getElementById('backgroundColors').value);
+  const textColors = parseColors(document.getElementById('textColors').value);
+  const text = document.getElementById('hiddenText').value.trim();
+  const pixelSize = parseInt(document.getElementById('pixelSize').value);
+  const textSizePercent = parseFloat(document.getElementById('textSize').value);
+  const posXPercent = parseFloat(document.getElementById('textX').value);
+  const posYPercent = parseFloat(document.getElementById('textY').value);
+  const angleDeg = parseFloat(document.getElementById('textAngle').value);
+  const textNoise = parseFloat(document.getElementById('textNoise').value) || 0;
+  const channel = (document.getElementById('channel').value || 'RB').toUpperCase();
+
+  if (!text || bgColors.length === 0 || textColors.length === 0) {
+    alert('Veuillez fournir un texte, des couleurs de fond et de texte.');
+    return;
+  }
+
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const cols = Math.floor(canvas.width / pixelSize);
+  const rows = Math.floor(canvas.height / pixelSize);
+
+  const temp = document.createElement('canvas');
+  temp.width = cols;
+  temp.height = rows;
+  const tctx = temp.getContext('2d');
+
+  tctx.fillStyle = 'white';
+  tctx.fillRect(0, 0, cols, rows);
+
+  tctx.save();
+  const centerX = (posXPercent / 100) * cols;
+  const centerY = (posYPercent / 100) * rows;
+  const angleRad = angleDeg * Math.PI / 180;
+  tctx.translate(centerX, centerY);
+  tctx.rotate(angleRad);
+  const fontSize = Math.floor((textSizePercent / 100) * rows);
+  tctx.font = `bold ${fontSize}px monospace`;
+  tctx.textAlign = 'center';
+  tctx.textBaseline = 'middle';
+  tctx.fillStyle = 'black';
+  tctx.fillText(text, 0, 0);
+  tctx.restore();
+
+  const mask = tctx.getImageData(0, 0, cols, rows).data;
+
+  for (let y = 0; y < rows; y++) {
+    for (let x = 0; x < cols; x++) {
+      const index = (y * cols + x) * 4;
+      const isText = mask[index] < 128;
+      const base = hexToRgb(bgColors[Math.floor(Math.random() * bgColors.length)]);
+      let color = { ...base };
+      if (isText || Math.random() * 100 < textNoise) {
+        const txt = hexToRgb(textColors[Math.floor(Math.random() * textColors.length)]);
+        if (channel === 'RB') {
+          color.r = txt.r;
+          color.b = 255 - txt.r;
+        } else if (channel === 'GR') {
+          color.g = txt.g;
+          color.r = 255 - txt.g;
+        } else { // BG
+          color.b = txt.b;
+          color.g = 255 - txt.b;
+        }
+      }
+      ctx.fillStyle = rgbToHex(color);
+      ctx.fillRect(x * pixelSize, y * pixelSize, pixelSize, pixelSize);
+    }
+  }
+
+  if (maskImage) {
+    ctx.globalCompositeOperation = 'destination-in';
+    ctx.drawImage(maskImage, 0, 0, canvas.width, canvas.height);
+    ctx.globalCompositeOperation = 'source-over';
+  }
+}
+
+export default {
+  name: 'Dichromatique',
+  generate: generateDichromatic,
+  options: {
+    ...pixel.options,
+    channel: 'RB'
+  },
+  visibleOptions: [...pixel.visibleOptions, 'channel']
+};

--- a/modes/differentialContrast.js
+++ b/modes/differentialContrast.js
@@ -1,0 +1,84 @@
+import pixel from './pixel.js';
+import { parseColors, maskImage, hexToRgb, rgbToHex } from '../utils.js';
+
+export function generateDifferentialContrast() {
+  const canvas = document.getElementById('canvas');
+  const ctx = canvas.getContext('2d');
+
+  const bgColors = parseColors(document.getElementById('backgroundColors').value);
+  const textColors = parseColors(document.getElementById('textColors').value);
+  const text = document.getElementById('hiddenText').value.trim();
+  const pixelSize = parseInt(document.getElementById('pixelSize').value);
+  const textSizePercent = parseFloat(document.getElementById('textSize').value);
+  const posXPercent = parseFloat(document.getElementById('textX').value);
+  const posYPercent = parseFloat(document.getElementById('textY').value);
+  const angleDeg = parseFloat(document.getElementById('textAngle').value);
+  const textNoise = parseFloat(document.getElementById('textNoise').value) || 0;
+  const contrast = (parseFloat(document.getElementById('contrast').value) || 10) / 100;
+
+  if (!text || bgColors.length === 0 || textColors.length === 0) {
+    alert('Veuillez fournir un texte, des couleurs de fond et de texte.');
+    return;
+  }
+
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const cols = Math.floor(canvas.width / pixelSize);
+  const rows = Math.floor(canvas.height / pixelSize);
+
+  const temp = document.createElement('canvas');
+  temp.width = cols;
+  temp.height = rows;
+  const tctx = temp.getContext('2d');
+
+  tctx.fillStyle = 'white';
+  tctx.fillRect(0, 0, cols, rows);
+
+  tctx.save();
+  const centerX = (posXPercent / 100) * cols;
+  const centerY = (posYPercent / 100) * rows;
+  const angleRad = angleDeg * Math.PI / 180;
+  tctx.translate(centerX, centerY);
+  tctx.rotate(angleRad);
+  const fontSize = Math.floor((textSizePercent / 100) * rows);
+  tctx.font = `bold ${fontSize}px monospace`;
+  tctx.textAlign = 'center';
+  tctx.textBaseline = 'middle';
+  tctx.fillStyle = 'black';
+  tctx.fillText(text, 0, 0);
+  tctx.restore();
+
+  const mask = tctx.getImageData(0, 0, cols, rows).data;
+
+  for (let y = 0; y < rows; y++) {
+    for (let x = 0; x < cols; x++) {
+      const index = (y * cols + x) * 4;
+      const isText = mask[index] < 128;
+      const bg = hexToRgb(bgColors[Math.floor(Math.random() * bgColors.length)]);
+      let color = { ...bg };
+      if (isText || Math.random() * 100 < textNoise) {
+        const txt = hexToRgb(textColors[Math.floor(Math.random() * textColors.length)]);
+        color.r = bg.r + (txt.r - bg.r) * contrast;
+        color.g = bg.g + (txt.g - bg.g) * contrast;
+        color.b = bg.b + (txt.b - bg.b) * contrast;
+      }
+      ctx.fillStyle = rgbToHex(color);
+      ctx.fillRect(x * pixelSize, y * pixelSize, pixelSize, pixelSize);
+    }
+  }
+
+  if (maskImage) {
+    ctx.globalCompositeOperation = 'destination-in';
+    ctx.drawImage(maskImage, 0, 0, canvas.width, canvas.height);
+    ctx.globalCompositeOperation = 'source-over';
+  }
+}
+
+export default {
+  name: 'Contraste Différentiel',
+  generate: generateDifferentialContrast,
+  options: {
+    ...pixel.options,
+    contrast: 10
+  },
+  visibleOptions: [...pixel.visibleOptions, 'contrast']
+};

--- a/modes/index.js
+++ b/modes/index.js
@@ -1,3 +1,19 @@
 import pixel from './pixel.js';
 import pixelSmooth from './pixelSmooth.js';
-export default [pixel, pixelSmooth];
+import selectiveChannel from './selectiveChannel.js';
+import dichromatic from './dichromatic.js';
+import differentialContrast from './differentialContrast.js';
+import anaglyph from './anaglyph.js';
+import physicalFilter from './physicalFilter.js';
+import chromaticInvert from './chromaticInvert.js';
+
+export default [
+  pixel,
+  pixelSmooth,
+  selectiveChannel,
+  dichromatic,
+  differentialContrast,
+  anaglyph,
+  physicalFilter,
+  chromaticInvert
+];

--- a/modes/physicalFilter.js
+++ b/modes/physicalFilter.js
@@ -1,0 +1,81 @@
+import pixel from './pixel.js';
+import { parseColors, maskImage, hexToRgb, rgbToHex } from '../utils.js';
+
+export function generatePhysicalFilter() {
+  const canvas = document.getElementById('canvas');
+  const ctx = canvas.getContext('2d');
+
+  const bgColors = parseColors(document.getElementById('backgroundColors').value);
+  const textColors = parseColors(document.getElementById('textColors').value);
+  const text = document.getElementById('hiddenText').value.trim();
+  const pixelSize = parseInt(document.getElementById('pixelSize').value);
+  const textSizePercent = parseFloat(document.getElementById('textSize').value);
+  const posXPercent = parseFloat(document.getElementById('textX').value);
+  const posYPercent = parseFloat(document.getElementById('textY').value);
+  const angleDeg = parseFloat(document.getElementById('textAngle').value);
+  const textNoise = parseFloat(document.getElementById('textNoise').value) || 0;
+  const contrast = 0.05; // faible contraste
+
+  if (!text || bgColors.length === 0 || textColors.length === 0) {
+    alert('Veuillez fournir un texte, des couleurs de fond et de texte.');
+    return;
+  }
+
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const cols = Math.floor(canvas.width / pixelSize);
+  const rows = Math.floor(canvas.height / pixelSize);
+
+  const temp = document.createElement('canvas');
+  temp.width = cols;
+  temp.height = rows;
+  const tctx = temp.getContext('2d');
+
+  tctx.fillStyle = 'white';
+  tctx.fillRect(0, 0, cols, rows);
+
+  tctx.save();
+  const centerX = (posXPercent / 100) * cols;
+  const centerY = (posYPercent / 100) * rows;
+  const angleRad = angleDeg * Math.PI / 180;
+  tctx.translate(centerX, centerY);
+  tctx.rotate(angleRad);
+  const fontSize = Math.floor((textSizePercent / 100) * rows);
+  tctx.font = `bold ${fontSize}px monospace`;
+  tctx.textAlign = 'center';
+  tctx.textBaseline = 'middle';
+  tctx.fillStyle = 'black';
+  tctx.fillText(text, 0, 0);
+  tctx.restore();
+
+  const mask = tctx.getImageData(0, 0, cols, rows).data;
+
+  for (let y = 0; y < rows; y++) {
+    for (let x = 0; x < cols; x++) {
+      const index = (y * cols + x) * 4;
+      const isText = mask[index] < 128;
+      const bg = hexToRgb(bgColors[Math.floor(Math.random() * bgColors.length)]);
+      let color = { ...bg };
+      if (isText || Math.random() * 100 < textNoise) {
+        const txt = hexToRgb(textColors[Math.floor(Math.random() * textColors.length)]);
+        color.r = bg.r + (txt.r - bg.r) * contrast;
+        color.g = bg.g + (txt.g - bg.g) * contrast;
+        color.b = bg.b + (txt.b - bg.b) * contrast;
+      }
+      ctx.fillStyle = rgbToHex(color);
+      ctx.fillRect(x * pixelSize, y * pixelSize, pixelSize, pixelSize);
+    }
+  }
+
+  if (maskImage) {
+    ctx.globalCompositeOperation = 'destination-in';
+    ctx.drawImage(maskImage, 0, 0, canvas.width, canvas.height);
+    ctx.globalCompositeOperation = 'source-over';
+  }
+}
+
+export default {
+  name: 'Filtre Physique',
+  generate: generatePhysicalFilter,
+  options: pixel.options,
+  visibleOptions: pixel.visibleOptions
+};

--- a/modes/selectiveChannel.js
+++ b/modes/selectiveChannel.js
@@ -1,0 +1,82 @@
+import pixel from './pixel.js';
+import { parseColors, maskImage, hexToRgb, rgbToHex } from '../utils.js';
+
+export function generateSelectiveChannel() {
+  const canvas = document.getElementById('canvas');
+  const ctx = canvas.getContext('2d');
+
+  const bgColors = parseColors(document.getElementById('backgroundColors').value);
+  const textColors = parseColors(document.getElementById('textColors').value);
+  const text = document.getElementById('hiddenText').value.trim();
+  const pixelSize = parseInt(document.getElementById('pixelSize').value);
+  const textSizePercent = parseFloat(document.getElementById('textSize').value);
+  const posXPercent = parseFloat(document.getElementById('textX').value);
+  const posYPercent = parseFloat(document.getElementById('textY').value);
+  const angleDeg = parseFloat(document.getElementById('textAngle').value);
+  const textNoise = parseFloat(document.getElementById('textNoise').value) || 0;
+  const channel = (document.getElementById('channel').value || 'R').toLowerCase();
+
+  if (!text || bgColors.length === 0 || textColors.length === 0) {
+    alert('Veuillez fournir un texte, des couleurs de fond et de texte.');
+    return;
+  }
+
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  const cols = Math.floor(canvas.width / pixelSize);
+  const rows = Math.floor(canvas.height / pixelSize);
+
+  const temp = document.createElement('canvas');
+  temp.width = cols;
+  temp.height = rows;
+  const tctx = temp.getContext('2d');
+
+  tctx.fillStyle = 'white';
+  tctx.fillRect(0, 0, cols, rows);
+
+  tctx.save();
+  const centerX = (posXPercent / 100) * cols;
+  const centerY = (posYPercent / 100) * rows;
+  const angleRad = angleDeg * Math.PI / 180;
+  tctx.translate(centerX, centerY);
+  tctx.rotate(angleRad);
+  const fontSize = Math.floor((textSizePercent / 100) * rows);
+  tctx.font = `bold ${fontSize}px monospace`;
+  tctx.textAlign = 'center';
+  tctx.textBaseline = 'middle';
+  tctx.fillStyle = 'black';
+  tctx.fillText(text, 0, 0);
+  tctx.restore();
+
+  const mask = tctx.getImageData(0, 0, cols, rows).data;
+
+  for (let y = 0; y < rows; y++) {
+    for (let x = 0; x < cols; x++) {
+      const index = (y * cols + x) * 4;
+      const isText = mask[index] < 128;
+      const baseColor = hexToRgb(bgColors[Math.floor(Math.random() * bgColors.length)]);
+      const color = { ...baseColor };
+      if (isText || Math.random() * 100 < textNoise) {
+        const txt = hexToRgb(textColors[Math.floor(Math.random() * textColors.length)]);
+        color[channel] = txt[channel];
+      }
+      ctx.fillStyle = rgbToHex(color);
+      ctx.fillRect(x * pixelSize, y * pixelSize, pixelSize, pixelSize);
+    }
+  }
+
+  if (maskImage) {
+    ctx.globalCompositeOperation = 'destination-in';
+    ctx.drawImage(maskImage, 0, 0, canvas.width, canvas.height);
+    ctx.globalCompositeOperation = 'source-over';
+  }
+}
+
+export default {
+  name: 'RGB Alterné',
+  generate: generateSelectiveChannel,
+  options: {
+    ...pixel.options,
+    channel: 'R'
+  },
+  visibleOptions: [...pixel.visibleOptions, 'channel']
+};

--- a/style.css
+++ b/style.css
@@ -21,7 +21,7 @@ label {
   font-weight: bold;
 }
 
-input, textarea {
+input, textarea, select {
   background: #222;
   color: #fff;
   padding: 8px;

--- a/utils.js
+++ b/utils.js
@@ -48,3 +48,21 @@ export function setupMaskUpload() {
     }
   });
 }
+
+export function hexToRgb(hex) {
+  hex = hex.replace('#', '');
+  if (hex.length === 3) {
+    hex = hex.split('').map(c => c + c).join('');
+  }
+  const num = parseInt(hex, 16);
+  return {
+    r: (num >> 16) & 255,
+    g: (num >> 8) & 255,
+    b: num & 255
+  };
+}
+
+export function rgbToHex({ r, g, b }) {
+  const toHex = c => Math.max(0, Math.min(255, c)).toString(16).padStart(2, '0');
+  return `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+}


### PR DESCRIPTION
## Summary
- extend utils with RGB helpers
- allow choosing color channel and contrast in the UI
- style `<select>` elements like other inputs
- add five new modes for color-based steganography
  - RGB Alterné
  - Dichromatique
  - Contraste Différentiel
  - Anaglyphe
  - Filtre Physique
  - Inversion Chromatique

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_b_6859ca292f40832c8be4b95d57c01740